### PR TITLE
Add check for header link and trailing slash

### DIFF
--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -1,6 +1,13 @@
 ---
 const { href, class: className, ...props } = Astro.props;
-let isActive = href === Astro.url.pathname;
+let isActive;
+
+if (href === "/") {
+	isActive = Astro.url.pathname === href;
+} else {
+	isActive = Astro.url.pathname.startsWith(href);
+}
+
 ---
 
 <a href={href} class:list={[className, { active: isActive }]} {...props}>


### PR DESCRIPTION
Fixes #21!

This was happening because on local, there's not a trailing slash on rendered pages, but on prod there is.