### PR TITLE
ignore generated astro files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,7 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
+# generated types
+/.astro/
+
 node_modules


### PR DESCRIPTION
Content collections adds a number of generated type files.

The only place I could find documentation about this is in https://github.com/withastro/astro/blob/7c7398c04653877da09c7b0f80ee84b02e02aad0/.gitignore#L32 . I guess this is undocumented as of now.